### PR TITLE
Change runner from self-hosted to ubuntu-latest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3


### PR DESCRIPTION
For å få builds til å passere. Sjekket actions -> runners og hadde ingen ingen self-hosted? ubuntu-latest skal være githubs egen